### PR TITLE
refacto(percentage): move percentage rollout to flag env

### DIFF
--- a/packages/backend/prisma/flag.prisma
+++ b/packages/backend/prisma/flag.prisma
@@ -8,14 +8,19 @@ model Flag {
 }
 
 model FlagEnvironment {
-    flag          Flag              @relation(fields: [flagId], references: [uuid])
+    flag          Flag        @relation(fields: [flagId], references: [uuid])
     flagId        String
-    environment   Environment       @relation(fields: [environmentId], references: [uuid])
+    environment   Environment @relation(fields: [environmentId], references: [uuid])
     environmentId String
     flagHit       FlagHit[]
+
     // the values set in flags/flag.status.ts
-    status        String            @default("NOT_ACTIVATED")
-    strategies    RolloutStrategy[]
+    status     String            @default("NOT_ACTIVATED")
+    strategies RolloutStrategy[]
+
+    // related to activation type "percentage"
+    rolloutPercentage Int
+    rolloutDate       DateTime?
 
     @@id([flagId, environmentId])
 }
@@ -39,9 +44,6 @@ model RolloutStrategy {
     fieldName        String?
     fieldComparator  String?
     fieldValue       String?
-
-    // related to activation type "percentage"
-    rolloutPercentage Int
 
     // Relations
     FlagEnvironment              FlagEnvironment? @relation(fields: [flagEnvironmentFlagId, flagEnvironmentEnvironmentId], references: [flagId, environmentId])

--- a/packages/backend/prisma/migrations/20220818055431_init/migration.sql
+++ b/packages/backend/prisma/migrations/20220818055431_init/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `rolloutPercentage` on the `RolloutStrategy` table. All the data in the column will be lost.
+  - Added the required column `rolloutPercentage` to the `FlagEnvironment` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "FlagEnvironment" ADD COLUMN     "rolloutDate" TIMESTAMP(3),
+ADD COLUMN     "rolloutPercentage" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "RolloutStrategy" DROP COLUMN "rolloutPercentage";

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -73,13 +73,15 @@ model Flag {
 }
 
 model FlagEnvironment {
-  flag          Flag              @relation(name: "FlagToFlagEnvironment", fields: [flagId], references: [uuid])
-  flagId        String
-  environment   Environment       @relation(name: "EnvironmentToFlagEnvironment", fields: [environmentId], references: [uuid])
-  environmentId String
-  flagHit       FlagHit[]         @relation(name: "FlagEnvironmentToFlagHit")
-  status        String            @default("NOT_ACTIVATED")
-  strategies    RolloutStrategy[] @relation(name: "FlagEnvironmentToRolloutStrategy")
+  flag              Flag              @relation(name: "FlagToFlagEnvironment", fields: [flagId], references: [uuid])
+  flagId            String
+  environment       Environment       @relation(name: "EnvironmentToFlagEnvironment", fields: [environmentId], references: [uuid])
+  environmentId     String
+  flagHit           FlagHit[]         @relation(name: "FlagEnvironmentToFlagHit")
+  status            String            @default("NOT_ACTIVATED")
+  strategies        RolloutStrategy[] @relation(name: "FlagEnvironmentToRolloutStrategy")
+  rolloutPercentage Int
+  rolloutDate       DateTime?
 
   @@id([flagId, environmentId])
 }
@@ -100,7 +102,6 @@ model RolloutStrategy {
   fieldName                    String?
   fieldComparator              String?
   fieldValue                   String?
-  rolloutPercentage            Int
   FlagEnvironment              FlagEnvironment? @relation(name: "FlagEnvironmentToRolloutStrategy", fields: [flagEnvironmentFlagId, flagEnvironmentEnvironmentId], references: [flagId, environmentId])
   flagEnvironmentFlagId        String?
   flagEnvironmentEnvironmentId String?

--- a/packages/backend/src/environments/environments.service.ts
+++ b/packages/backend/src/environments/environments.service.ts
@@ -72,6 +72,7 @@ export class EnvironmentsService {
       data: {
         flagId: flag.uuid,
         environmentId: envId,
+        rolloutPercentage: 100,
       },
     });
 

--- a/packages/backend/src/flags/types.ts
+++ b/packages/backend/src/flags/types.ts
@@ -19,10 +19,10 @@ export interface FlagEnvironment {
   flagId: string;
   environmentId: string;
   status: string;
+  rolloutPercentage: number;
 }
 
 export interface PopulatedFlagEnv extends FlagEnvironment {
-  environment: Environment;
   flag: Flag;
   strategies: Array<RolloutStrategy>;
 }

--- a/packages/backend/src/shared/utils/generateBucketId.ts
+++ b/packages/backend/src/shared/utils/generateBucketId.ts
@@ -20,7 +20,7 @@ export const isInRange = (bucket: number, rolloutPercentage: number) => {
   return bucket < higherBoundActivationThreshold;
 };
 
-export const genBucket = (key: string, userId: string) => {
+export const genBucket = (userId: string, key: string) => {
   const bucketKey = `${userId}-${key}`;
   const bucketHash: number = murmur.hash32(bucketKey, 1);
   const bucketHashRatio = bucketHash / MAX_INT_32; // int 32 hash divided by the max number of int 32

--- a/packages/backend/src/strategy/strategy.dto.ts
+++ b/packages/backend/src/strategy/strategy.dto.ts
@@ -9,9 +9,6 @@ export class StrategyCreationDTO {
   fieldName?: string;
   fieldComparator?: ComparatorEnum;
   fieldValue?: string;
-
-  // only exists for activation "percentage"
-  rolloutPercentage?: number;
 }
 
 export const StrategySchema = Joi.object({
@@ -29,11 +26,4 @@ export const StrategySchema = Joi.object({
   fieldValue: Joi.string().when('strategyRuleType', {
     switch: [{ is: 'field', then: Joi.required() }],
   }),
-
-  rolloutPercentage: Joi.number()
-    .integer()
-    .positive()
-    .min(0)
-    .max(100)
-    .required(),
 });

--- a/packages/backend/src/strategy/strategy.service.spec.ts
+++ b/packages/backend/src/strategy/strategy.service.spec.ts
@@ -35,7 +35,6 @@ describe('StrategyService', () => {
       flagEnvironmentEnvironmentId: '1',
       flagEnvironmentFlagId: '1',
       name: 'Strategy name',
-      rolloutPercentage: 100,
       strategyRuleType: StrategyRuleType.Default,
       uuid: '123',
     };
@@ -51,6 +50,7 @@ describe('StrategyService', () => {
         name: 'Super flag',
       },
       status: FlagStatus.ACTIVATED,
+      rolloutPercentage: 100,
     };
   });
 
@@ -67,7 +67,7 @@ describe('StrategyService', () => {
 
     describe('Percentage rollout', () => {
       it('returns true when the rollout percentage is 100%', async () => {
-        strategy.rolloutPercentage = 100;
+        flagEnv.rolloutPercentage = 100;
 
         const shouldActivate = await service.resolveStrategies(
           flagEnv,
@@ -80,8 +80,8 @@ describe('StrategyService', () => {
         expect(shouldActivate).toBe(true);
       });
 
-      it('returns false when the activation rule is Percentage but the userId is falsy', async () => {
-        strategy.rolloutPercentage = 99;
+      it('returns false when the userId is falsy', async () => {
+        flagEnv.rolloutPercentage = 99;
 
         const shouldActivate = await service.resolveStrategies(
           flagEnv,
@@ -92,8 +92,8 @@ describe('StrategyService', () => {
         expect(shouldActivate).toBe(false);
       });
 
-      it('returns true when the activation rule is Percentage, the userId is falsy BUT the percentage is 100', async () => {
-        strategy.rolloutPercentage = 100;
+      it('returns true when the userId is falsy BUT the percentage is 100', async () => {
+        flagEnv.rolloutPercentage = 100;
 
         const shouldActivate = await service.resolveStrategies(
           flagEnv,
@@ -104,8 +104,8 @@ describe('StrategyService', () => {
         expect(shouldActivate).toBe(true);
       });
 
-      it('returns true when the ActivationRuleType is Percentage (70%) and that the user/flag combination is in the percentage range', async () => {
-        strategy.rolloutPercentage = 70;
+      it('returns true when percentage of rollout is 70% and that the user/flag combination is in the percentage range', async () => {
+        flagEnv.rolloutPercentage = 70;
 
         const shouldActivate = await service.resolveStrategies(
           flagEnv,
@@ -118,8 +118,8 @@ describe('StrategyService', () => {
         expect(shouldActivate).toBe(true);
       });
 
-      it('returns false when the ActivationRuleType is Percentage (5%) and that the user/flag combination is NOT in the percentage range', async () => {
-        strategy.rolloutPercentage = 5;
+      it('returns false when percentage of rollout is 5% and that the user/flag combination is NOT in the percentage range', async () => {
+        flagEnv.rolloutPercentage = 5;
 
         const shouldActivate = await service.resolveStrategies(
           flagEnv,

--- a/packages/backend/src/strategy/types.ts
+++ b/packages/backend/src/strategy/types.ts
@@ -23,7 +23,6 @@ export interface RolloutStrategy {
   fieldName?: string;
   fieldComparator?: ComparatorEnum;
   fieldValue?: string;
-  rolloutPercentage: number;
   flagEnvironmentFlagId?: string;
   flagEnvironmentEnvironmentId?: string;
 }

--- a/packages/backend/test/flags/flags.e2e-spec.ts
+++ b/packages/backend/test/flags/flags.e2e-spec.ts
@@ -276,7 +276,6 @@ describe('FlagsController (e2e)', () => {
       const validStrategy: any = {
         name: 'Super strategy',
         strategyRuleType: 'default',
-        rolloutPercentage: 100,
       };
 
       return request(app.getHttpServer())
@@ -304,7 +303,6 @@ describe('FlagsController (e2e)', () => {
         .send({
           name: 'Super strategy',
           strategyRuleType: 'field',
-          rolloutPercentage: 100,
           fieldName: 'email',
           fieldComparator: 'eq',
           fieldValue: 'marvin.frachet@something.com\njohn.doe@gmail.com',
@@ -323,7 +321,6 @@ describe('FlagsController (e2e)', () => {
       const invalidStrategy: any = {
         name: undefined,
         strategyRuleType: 'default',
-        rolloutPercentage: 100,
       };
 
       await request(app.getHttpServer())
@@ -344,7 +341,6 @@ describe('FlagsController (e2e)', () => {
       const invalidStrategy: any = {
         name: 'Super strategy',
         strategyRuleType: 'invalid strategy',
-        rolloutPercentage: 100,
       };
 
       await request(app.getHttpServer())
@@ -366,7 +362,6 @@ describe('FlagsController (e2e)', () => {
         const invalidStrategy: any = {
           name: 'Super strategy',
           strategyRuleType: 'field',
-          rolloutPercentage: 100,
           [field]: undefined,
         };
 
@@ -389,7 +384,6 @@ describe('FlagsController (e2e)', () => {
       const validStrategy: any = {
         name: 'Super strategy',
         strategyRuleType: 'default',
-        rolloutPercentage: 100,
       };
 
       const response = await request(app.getHttpServer())
@@ -407,7 +401,6 @@ describe('FlagsController (e2e)', () => {
         fieldName: null,
         fieldComparator: null,
         fieldValue: null,
-        rolloutPercentage: 100,
         flagEnvironmentFlagId: '1',
         flagEnvironmentEnvironmentId: '1',
       });
@@ -419,7 +412,6 @@ describe('FlagsController (e2e)', () => {
       const validStrategy: any = {
         name: 'Super strategy',
         strategyRuleType: 'field',
-        rolloutPercentage: 100,
         fieldName: 'email',
         fieldComparator: 'eq',
         fieldValue: 'marvin.frachet@something.com\njohn.doe@gmail.com',
@@ -440,7 +432,6 @@ describe('FlagsController (e2e)', () => {
         fieldName: 'email',
         fieldComparator: 'eq',
         fieldValue: 'marvin.frachet@something.com\njohn.doe@gmail.com',
-        rolloutPercentage: 100,
         flagEnvironmentFlagId: '1',
         flagEnvironmentEnvironmentId: '1',
       });
@@ -455,7 +446,6 @@ describe('FlagsController (e2e)', () => {
         fieldName: 'email',
         fieldComparator: 'eq',
         fieldValue: 'marvin.frachet@something.com\njohn.doe@gmail.com',
-        rolloutPercentage: 99,
       };
 
       const response = await request(app.getHttpServer())
@@ -473,7 +463,6 @@ describe('FlagsController (e2e)', () => {
         fieldName: 'email',
         fieldComparator: 'eq',
         fieldValue: 'marvin.frachet@something.com\njohn.doe@gmail.com',
-        rolloutPercentage: 99,
         flagEnvironmentFlagId: '1',
         flagEnvironmentEnvironmentId: '1',
       });
@@ -525,7 +514,6 @@ describe('FlagsController (e2e)', () => {
         fieldName: 'email',
         fieldComparator: 'eq',
         fieldValue: 'marvin.frachet@something.com\njohn.doe@gmail.com',
-        rolloutPercentage: 99,
       };
 
       // Create a strategy to check it works
@@ -547,7 +535,6 @@ describe('FlagsController (e2e)', () => {
       expect(newStrat.flagEnvironmentEnvironmentId).toEqual('1');
       expect(newStrat.flagEnvironmentFlagId).toEqual('1');
       expect(newStrat.name).toEqual('Super strategy');
-      expect(newStrat.rolloutPercentage).toEqual(100);
       expect(newStrat.strategyRuleType).toEqual('default');
       expect(newStrat.uuid).toBeDefined();
     });

--- a/packages/backend/test/helpers/seed.ts
+++ b/packages/backend/test/helpers/seed.ts
@@ -69,6 +69,7 @@ export const seedDb = async () => {
       data: {
         environmentId: production.uuid,
         flagId: homePageFlag.uuid,
+        rolloutPercentage: 100,
       },
     });
 
@@ -77,6 +78,7 @@ export const seedDb = async () => {
         environmentId: production.uuid,
         flagId: footerFlag.uuid,
         status: 'ACTIVATED',
+        rolloutPercentage: 100,
       },
     });
 
@@ -84,6 +86,7 @@ export const seedDb = async () => {
       data: {
         environmentId: otherEnv.uuid,
         flagId: asideFlag.uuid,
+        rolloutPercentage: 100,
       },
     });
 
@@ -94,7 +97,6 @@ export const seedDb = async () => {
         flagEnvironmentEnvironmentId: flagEnv.environmentId,
         name: 'Super strategy',
         strategyRuleType: 'default',
-        rolloutPercentage: 100,
       },
     });
 
@@ -105,7 +107,6 @@ export const seedDb = async () => {
         flagEnvironmentEnvironmentId: footerFlagEnv.environmentId,
         name: 'Field based',
         strategyRuleType: 'field',
-        rolloutPercentage: 100,
         fieldName: 'id',
         fieldComparator: 'eq',
         fieldValue: '1',
@@ -119,7 +120,6 @@ export const seedDb = async () => {
         flagEnvironmentEnvironmentId: otherFlagEnv.environmentId,
         name: 'Super strategy',
         strategyRuleType: 'default',
-        rolloutPercentage: 100,
       },
     });
 

--- a/packages/backend/test/strategy/strategy.e2e-spec.ts
+++ b/packages/backend/test/strategy/strategy.e2e-spec.ts
@@ -75,7 +75,6 @@ describe('Strategy (e2e)', () => {
         flagEnvironmentEnvironmentId: '1',
         flagEnvironmentFlagId: '1',
         name: 'Super strategy',
-        rolloutPercentage: 100,
         strategyRuleType: 'default',
         uuid: '1',
       });
@@ -133,7 +132,6 @@ describe('Strategy (e2e)', () => {
           "flagEnvironmentEnvironmentId": "1",
           "flagEnvironmentFlagId": "1",
           "name": "Super strategy",
-          "rolloutPercentage": 100,
           "strategyRuleType": "default",
           "uuid": "1",
         }
@@ -150,7 +148,6 @@ describe('Strategy (e2e)', () => {
           fieldName: null,
           fieldComparator: null,
           fieldValue: null,
-          rolloutPercentage: 100,
           flagEnvironmentFlagId: '1',
           flagEnvironmentEnvironmentId: '1',
         });
@@ -211,7 +208,6 @@ describe('Strategy (e2e)', () => {
       const invalidStrategy: any = {
         name: undefined,
         strategyRuleType: 'default',
-        rolloutPercentage: 100,
       };
 
       await request(app.getHttpServer())
@@ -232,7 +228,6 @@ describe('Strategy (e2e)', () => {
       const invalidStrategy: any = {
         name: 'Super strategy',
         strategyRuleType: 'invalid strategy',
-        rolloutPercentage: 100,
       };
 
       await request(app.getHttpServer())
@@ -254,7 +249,6 @@ describe('Strategy (e2e)', () => {
         const invalidStrategy: any = {
           name: 'Super strategy',
           strategyRuleType: 'field',
-          rolloutPercentage: 100,
           [field]: undefined,
         };
 
@@ -277,7 +271,6 @@ describe('Strategy (e2e)', () => {
       const validStrategy: any = {
         name: 'Super strategy 2',
         strategyRuleType: 'default',
-        rolloutPercentage: 67,
       };
 
       const response = await request(app.getHttpServer())
@@ -295,7 +288,6 @@ describe('Strategy (e2e)', () => {
         fieldName: null,
         fieldComparator: null,
         fieldValue: null,
-        rolloutPercentage: 67,
         flagEnvironmentFlagId: '1',
         flagEnvironmentEnvironmentId: '1',
       });


### PR DESCRIPTION
In order to keep things simple for now, let's assume that percentage based rollout are only available at the flag-env level and not at the strategy level