### PR TITLE
test(e2e): explicit wait for CSS transition when axe hits

### DIFF
--- a/packages/frontend/cypress/e2e/forgot-password.spec.ts
+++ b/packages/frontend/cypress/e2e/forgot-password.spec.ts
@@ -26,6 +26,7 @@ describe("/forgot-password", () => {
   it("shows an error message when the email is empty", () => {
     cy.findByRole("button", { name: "Reset password" }).click();
 
+    cy.wait(500); // Wait for the CSS transition
     cy.get(".error-box")
       .should("have.focus")
       .and("contain.text", "The email field is required.");

--- a/packages/frontend/cypress/e2e/onboarding.spec.ts
+++ b/packages/frontend/cypress/e2e/onboarding.spec.ts
@@ -35,6 +35,8 @@ describe("/dashboard/onboarding", () => {
 
     it("shows an error when submitting an empty form", () => {
       cy.findByRole("button", { name: "Create the project" }).click();
+
+      cy.wait(500); // Wait for the CSS transition
       cy.get(".error-box")
         .should("have.focus")
         .and(
@@ -48,6 +50,8 @@ describe("/dashboard/onboarding", () => {
     it("creates a new project", () => {
       cy.get("input").type("My new project");
       cy.findByRole("button", { name: "Create the project" }).click();
+
+      cy.wait(500); // Wait for the CSS transition
       cy.get(".success-box")
         .should("have.focus")
         .and("contain.text", "The project has been successfully created.");

--- a/packages/frontend/cypress/e2e/projects/create.spec.ts
+++ b/packages/frontend/cypress/e2e/projects/create.spec.ts
@@ -49,6 +49,7 @@ describe("/dashboard/projects/create", () => {
     it("shows an error when submitting an empty form", () => {
       cy.findByRole("button", { name: "Create the project" }).click();
 
+      cy.wait(500); // Wait for the CSS transition
       cy.get(".error-box")
         .should("have.focus")
         .and(
@@ -63,6 +64,7 @@ describe("/dashboard/projects/create", () => {
       cy.findByLabelText("Project name").type("My new project");
       cy.findByRole("button", { name: "Create the project" }).click();
 
+      cy.wait(500); // Wait for the CSS transition
       cy.get(".success-box")
         .should("have.focus")
         .and("contain.text", "The project has been successfully created.");

--- a/packages/frontend/cypress/e2e/projects/id/add-member.spec.ts
+++ b/packages/frontend/cypress/e2e/projects/id/add-member.spec.ts
@@ -80,6 +80,7 @@ describe("/dashboard/projects/[id]/add-member", () => {
           cy.findByLabelText("Member email").type("lol");
           cy.findByRole("button", { name: "Add the member" }).click();
 
+          cy.wait(500); // Wait for the CSS transition
           cy.get(".error-box")
             .should("have.focus")
             .and(
@@ -96,6 +97,7 @@ describe("/dashboard/projects/[id]/add-member", () => {
           );
           cy.findByRole("button", { name: "Add the member" }).click();
 
+          cy.wait(500); // Wait for the CSS transition
           cy.get(".error-box")
             .should("have.focus")
             .and(
@@ -127,6 +129,7 @@ describe("/dashboard/projects/[id]/add-member", () => {
           cy.findByLabelText("Member email").type("jane.doe@gmail.com");
           cy.findByRole("button", { name: "Add the member" }).click();
 
+          cy.wait(500); // Wait for the CSS transition
           cy.get(".success-box")
             .should("have.focus")
             .and(

--- a/packages/frontend/cypress/e2e/projects/id/environments/create.spec.ts
+++ b/packages/frontend/cypress/e2e/projects/id/environments/create.spec.ts
@@ -71,6 +71,8 @@ describe("/dashboard/projects/[id]/environments/create", () => {
 
       it("shows an error when submitting an empty form", () => {
         cy.findByRole("button", { name: "Create the environment" }).click();
+
+        cy.wait(500); // Wait for the CSS transition
         cy.get(".error-box")
           .should("have.focus")
           .and(
@@ -85,6 +87,7 @@ describe("/dashboard/projects/[id]/environments/create", () => {
         cy.findByLabelText("Environment name").type("My new env");
         cy.findByRole("button", { name: "Create the environment" }).click();
 
+        cy.wait(500); // Wait for the CSS transition
         cy.get(".success-box")
           .should("have.focus")
           .and(

--- a/packages/frontend/cypress/e2e/projects/id/environments/envId/flags/create.spec.ts
+++ b/packages/frontend/cypress/e2e/projects/id/environments/envId/flags/create.spec.ts
@@ -85,6 +85,7 @@ describe("/dashboard/projects/[id]/environments/[envId]/flags/create", () => {
       it("shows an error when submitting an empty form", () => {
         cy.findByRole("button", { name: "Create the feature flag" }).click();
 
+        cy.wait(500); // Wait for the CSS transition
         cy.get(".error-box")
           .should("have.focus")
           .and(
@@ -104,6 +105,7 @@ describe("/dashboard/projects/[id]/environments/[envId]/flags/create", () => {
         cy.findByLabelText("Flag description").type("My new flag description");
         cy.findByRole("button", { name: "Create the feature flag" }).click();
 
+        cy.wait(500); // Wait for the CSS transition
         cy.get(".success-box")
           .should("have.focus")
           .and("contain.text", "The flag has been successfully created.");

--- a/packages/frontend/cypress/e2e/projects/id/environments/envId/flags/flagId/scheduling/create.spec.ts
+++ b/packages/frontend/cypress/e2e/projects/id/environments/envId/flags/flagId/scheduling/create.spec.ts
@@ -116,6 +116,7 @@ describe("/dashboard/projects/[id]/environments/[envId]/flags/[flagId]/schedulin
           "/dashboard/projects/1/environments/1/flags/1/scheduling?newSchedule=true"
         );
 
+        cy.wait(500); // Wait for the CSS transition
         cy.get(".success-box")
           .should("have.focus")
           .and("contain.text", "The schedule has been successfully added.");

--- a/packages/frontend/cypress/e2e/projects/id/environments/envId/flags/flagId/strategy/$stratId.edit.spec.ts
+++ b/packages/frontend/cypress/e2e/projects/id/environments/envId/flags/flagId/strategy/$stratId.edit.spec.ts
@@ -106,6 +106,7 @@ describe("/dashboard/projects/[id]/environments/[envId]/flags/[flagId]/strategie
         });
         cy.findByRole("button", { name: "Save the strategy" }).click();
 
+        cy.wait(500); // Wait for the CSS transition
         cy.get(".error-box")
           .should("have.focus")
           .and("contain.text", "The following 2 errors have been found:")
@@ -124,6 +125,7 @@ describe("/dashboard/projects/[id]/environments/[envId]/flags/[flagId]/strategie
           "/dashboard/projects/1/environments/1/flags/1?strategyUpdated=true"
         );
 
+        cy.wait(500); // Wait for the CSS transition
         cy.get(".success-box")
           .should("have.focus")
           .and("contain.text", "The strategy has been successfully updated.");

--- a/packages/frontend/cypress/e2e/projects/id/environments/envId/flags/flagId/strategy/create.spec.ts
+++ b/packages/frontend/cypress/e2e/projects/id/environments/envId/flags/flagId/strategy/create.spec.ts
@@ -110,6 +110,7 @@ describe("/dashboard/projects/[id]/environments/[envId]/flags/[flagId]/strategie
         });
         cy.findByRole("button", { name: "Save the strategy" }).click();
 
+        cy.wait(500); // Wait for the CSS transition
         cy.get(".error-box")
           .should("have.focus")
           .and("contain.text", "The following 3 errors have been found:")
@@ -130,6 +131,7 @@ describe("/dashboard/projects/[id]/environments/[envId]/flags/[flagId]/strategie
           "/dashboard/projects/1/environments/1/flags/1?newStrategy=true"
         );
 
+        cy.wait(500); // Wait for the CSS transition
         cy.get(".success-box")
           .should("have.focus")
           .and("contain.text", "The strategy has been successfully created.");

--- a/packages/frontend/cypress/e2e/projects/id/settings.spec.ts
+++ b/packages/frontend/cypress/e2e/projects/id/settings.spec.ts
@@ -71,6 +71,7 @@ describe("/dashboard/projects/[id]/settings", () => {
         cy.get("#col-1").last().click();
         cy.findByRole("button", { name: "Remove from project" }).click();
 
+        cy.wait(500); // Wait for the CSS transition
         cy.get(".error-box")
           .should("have.focus")
           .and(
@@ -85,6 +86,7 @@ describe("/dashboard/projects/[id]/settings", () => {
         cy.get("#col-2").last().click();
         cy.findByRole("button", { name: "Remove from project" }).click();
 
+        cy.wait(500); // Wait for the CSS transition
         cy.get(".success-box")
           .should("have.focus")
           .and(

--- a/packages/frontend/cypress/e2e/register.spec.ts
+++ b/packages/frontend/cypress/e2e/register.spec.ts
@@ -11,6 +11,7 @@ describe("/register", () => {
     cy.findByLabelText("Email").type("invalid@email");
     cy.findByRole("button", { name: "Create an account" }).click();
 
+    cy.wait(500); // Wait for the CSS transition
     cy.get(".error-box")
       .should("have.focus")
       .and(
@@ -34,6 +35,7 @@ describe("/register", () => {
   it("gives feedbacks when the required fields are not filled", () => {
     cy.findByRole("button", { name: "Create an account" }).click();
 
+    cy.wait(500); // Wait for the CSS transition
     cy.get(".error-box")
       .should("have.focus")
       .and("contain.text", "The email field is required.")
@@ -50,6 +52,7 @@ describe("/register", () => {
     cy.findByLabelText("Confirm your password").type("aabcd");
     cy.findByRole("button", { name: "Create an account" }).click();
 
+    cy.wait(500); // Wait for the CSS transition
     cy.get(".error-box")
       .should("have.focus")
       .and("contain.text", "The two passwords are not the same.");
@@ -65,6 +68,7 @@ describe("/register", () => {
     cy.findByLabelText("Confirm your password").type("12345678901112");
     cy.findByRole("button", { name: "Create an account" }).click();
 
+    cy.wait(500); // Wait for the CSS transition
     cy.get(".error-box")
       .should("have.focus")
       .and("contain.text", "This email is already used.");

--- a/packages/frontend/cypress/e2e/signin.spec.ts
+++ b/packages/frontend/cypress/e2e/signin.spec.ts
@@ -38,6 +38,7 @@ describe("/signin", () => {
   it("gives feedbacks when the required fields are not filled", () => {
     cy.findByRole("button", { name: "Sign in" }).click();
 
+    cy.wait(500); // Wait for the CSS transition
     cy.get(".error-box")
       .should("have.focus")
       .and("contain.text", "The email field is required.")
@@ -53,6 +54,7 @@ describe("/signin", () => {
 
     cy.findByRole("button", { name: "Sign in" }).click();
 
+    cy.wait(500); // Wait for the CSS transition
     cy.get(".error-box")
       .should("have.focus")
       .and("contain.text", "Woops! Looks the credentials are not valid.");

--- a/packages/frontend/cypress/e2e/welcome.spec.ts
+++ b/packages/frontend/cypress/e2e/welcome.spec.ts
@@ -34,6 +34,7 @@ describe("/welcome", () => {
   it("gives feedbacks when the required fields are not filled", () => {
     cy.findByRole("button", { name: "Create an account" }).click();
 
+    cy.wait(500); // Wait for the CSS transition
     cy.get(".error-box")
       .should("have.focus")
       .and("contain.text", "The email field is required.")

--- a/packages/frontend/cypress/e2e/what-s-your-name.spec.ts
+++ b/packages/frontend/cypress/e2e/what-s-your-name.spec.ts
@@ -33,6 +33,8 @@ describe("/dashboard/what-s-your-name", () => {
 
     it("shows an error when submitting an empty form", () => {
       cy.findByRole("button", { name: "Set my fullname" }).click();
+
+      cy.wait(500); // Wait for the CSS transition
       cy.get(".error-box")
         .should("have.focus")
         .and(


### PR DESCRIPTION
There's a fadein animation on success and error boxes that throws. Sometimes, when axe tries to check the page, it's in the middle of the transition and it throws an error because of insufficient color contrast.

I've put explicit await moment before making the assertions so that it should be less flaky on ci