### PR TITLE
feat(documentation): allow percentage update before flag activation

### DIFF
--- a/packages/website/src/components/CorrelatePercentageError.tsx
+++ b/packages/website/src/components/CorrelatePercentageError.tsx
@@ -46,8 +46,11 @@ const Histogram = ({ percentage }: { percentage: number }) => {
 };
 
 export const CorrelatePercentageError = () => {
-  const [percentage, setPercentage] = useState(10);
+  const [percentage, setPercentage] = useState(20);
   const [checked, setChecked] = useState(false);
+
+  const errorLevelPercentage = checked ? percentage : 10;
+
   return (
     <div>
       <div className="px-4 md:px-8 max-w-6xl mx-auto">
@@ -75,9 +78,7 @@ export const CorrelatePercentageError = () => {
                 <NumberInput
                   value={percentage}
                   onChange={(n) => {
-                    if (checked) {
-                      setPercentage(n);
-                    }
+                    setPercentage(n);
                   }}
                 />
               </div>
@@ -98,7 +99,7 @@ export const CorrelatePercentageError = () => {
                 </p>
               </div>
 
-              <Histogram percentage={percentage} />
+              <Histogram percentage={errorLevelPercentage} />
             </Card>
           </div>
         </section>

--- a/packages/website/src/components/CorrelatePercentageError.tsx
+++ b/packages/website/src/components/CorrelatePercentageError.tsx
@@ -46,7 +46,7 @@ const Histogram = ({ percentage }: { percentage: number }) => {
 };
 
 export const CorrelatePercentageError = () => {
-  const [percentage, setPercentage] = useState(20);
+  const [percentage, setPercentage] = useState(35);
   const [checked, setChecked] = useState(false);
 
   const errorLevelPercentage = checked ? percentage : 10;


### PR DESCRIPTION
Strange feeling about not being able to update percentage while flag isn't enabled.

Also, enabling flag should cause a variation on error level in order to display the impact without having to update percentage of user impacted.
