### PR TITLE
feat(project): include the flagEnvironment when retrieving project's flags

### DIFF
--- a/packages/backend/src/projects/projects.service.ts
+++ b/packages/backend/src/projects/projects.service.ts
@@ -10,6 +10,9 @@ export class ProjectsService {
 
   flagsByProject(projectId: string) {
     return this.prisma.flag.findMany({
+      include: {
+        flagEnvironment: true,
+      },
       where: {
         flagEnvironment: {
           some: {


### PR DESCRIPTION
I need it on the CLI.

Does it have a bad impact on performances on the dashboard's side ?