### PR TITLE
chore(turbo): make dev script depends of build of dependencies

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,7 @@
       "dependsOn": []
     },
     "dev": {
-      "dependsOn": []
+      "dependsOn": ["^build"]
     },
     "db:migrate:init": {
       "dependsOn": []


### PR DESCRIPTION
When you first launch `pnpm dev` you'll get an error because all packages that needs build like prisma client aren't built yet.

This ensure they're built and cached by turbo :) 