### PR TITLE
fix: put the promotion banner at the bottom to let the showcase visible

### DIFF
--- a/packages/website/src/components/PullTriggerSection.tsx
+++ b/packages/website/src/components/PullTriggerSection.tsx
@@ -81,7 +81,7 @@ export const PullTriggerSection = ({
           <Browser>
             {newPricingSection && (
               <div
-                className={`${sharedLineClass} motion-safe:animate-fade-enter-top !rounded-none !bg-[#44BCFF] !h-8 absolute z-10 w-full flex flex-row items-center justify-center gap-2`}
+                className={`${sharedLineClass} motion-safe:animate-fade-enter-top !rounded-none !bg-[#44BCFF] !h-8 absolute bottom-0 z-10 w-full flex flex-row items-center justify-center gap-2`}
               >
                 <p className="text-xs text-white">Get 20% for free!</p>
 


### PR DESCRIPTION
On prod when Showcase can be hidden by the new pricing section.

![image](https://github.com/progressively-crew/progressively/assets/22884251/242c9b49-7ea9-4637-b858-d24228e21e31)

![image](https://github.com/progressively-crew/progressively/assets/22884251/de24a214-c7be-456d-b839-2e74e22cc114)

So I put the new pricing at the bottom

<img width="885" alt="Capture d’écran 2023-08-25 à 15 17 33" src="https://github.com/progressively-crew/progressively/assets/22884251/6d41bba0-22c7-4eeb-bf9b-8ffdc49cbaa9">